### PR TITLE
remove strange outline of scrollbar

### DIFF
--- a/frontend/src/style.scss
+++ b/frontend/src/style.scss
@@ -123,7 +123,6 @@ body {
  
 ::-webkit-scrollbar-thumb {
   background-color: $gray;
-  outline: 1px solid $gray;
   border-radius: 4px;
 }
 


### PR DESCRIPTION
the bug:
<img width="78" alt="Screenshot 2021-08-13 at 12 27 41" src="https://user-images.githubusercontent.com/18725968/129343868-1f2f835e-9b6e-43a9-971d-d55f9099c809.png">

appeared on webkit/safari